### PR TITLE
Adding IMPRESS extractor test suite and re thinking extraction strategy

### DIFF
--- a/impc_etl/impc_etl.py
+++ b/impc_etl/impc_etl.py
@@ -1,6 +1,33 @@
 """
 IMPC ETL Pipeline
 """
+import os
+import sys
+if os.path.exists('libs.zip'):
+    sys.path.insert(0, 'libs.zip')
+else:
+    sys.path.insert(0, './libs')
+
+if os.path.exists('jobs.zip'):
+    sys.path.insert(0, 'jobs.zip')
+else:
+    sys.path.insert(0, './jobs')
+
+if os.path.exists('shared.zip'):
+    sys.path.insert(0, 'shared.zip')
+else:
+    sys.path.insert(0, './shared')
+
+# pylint:disable=E0401
+try:
+    import pyspark
+except:
+    import findspark
+    findspark.init()
+    import pyspark
+
+from pyspark import SparkConf
+from pyspark.sql import SparkSession
 
 
 def impc_pipeline(spark_context):
@@ -17,5 +44,14 @@ def main():
 
     :return:
     """
-    spark_context = {}
-    impc_pipeline(spark_context)
+    conf = SparkConf().setAll([('spark.jars.packages', ['com.databricks:spark-xml_2.11:0.4.1'])])
+    spark = SparkSession.builder.appName("IMPC_ETL_TEST").config(conf=conf).getOrCreate()
+    experiment_file = "./impc_data/*experiment*"
+    experiments_df = spark.read.format("com.databricks.spark.xml") \
+        .options(rowTag="centre").load(experiment_file, )
+    experiments_df.show()
+    experiments_df.printSchema()
+
+
+if __name__ == "__main__":
+    main()

--- a/impc_etl/jobs/extraction/dcc_extractor.py
+++ b/impc_etl/jobs/extraction/dcc_extractor.py
@@ -10,7 +10,7 @@ DCC loader module
 from typing import Tuple
 
 from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.functions import explode
+from pyspark.sql.functions import explode, concat_ws
 
 
 def extract_observations(spark_session: SparkSession, file_path: str) -> Tuple[DataFrame, DataFrame]:

--- a/impc_etl/jobs/extraction/impress_extractor.py
+++ b/impc_etl/jobs/extraction/impress_extractor.py
@@ -1,5 +1,48 @@
 """
-IMPRESS loader
-    load_procedures: load impress procedures
-    load_parameters: load impress parameters
+IMPRESS extractor
+    extract_impress: Extract Impress data and load it to a dratafram
 """
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import ArrayType
+from pyspark.sql.functions import udf, explode
+import requests
+from typing import List
+from impc_etl.shared.utils import convert_to_row
+
+
+def extract_impress(spark_session: SparkSession, impress_api_url: str, start_type: str) -> DataFrame:
+    root_index = requests.get("{}/{}/list".format(impress_api_url, start_type)).json()
+    root_ids = [key for key in root_index.keys()]
+    return get_entities_dataframe(spark_session, impress_api_url, start_type, root_ids)
+
+
+def get_entities_dataframe(spark_session: SparkSession, impress_api_url, impress_type: str, impress_ids: List[str]):
+    entities = [get_impress_entity_by_id(impress_api_url, impress_type, impress_id) for impress_id in
+                impress_ids]
+    entity_df = spark_session.createDataFrame(convert_to_row(entity) for entity in entities)
+    for column_name in entity_df.schema.names:
+        if 'Collection' in column_name:
+            impress_subtype = column_name.replace('Collection', '')
+            exploded = entity_df.withColumn(impress_subtype + 'Id', explode(entity_df[column_name]))
+            exploded.show()
+            # impress_entity_schema = get_impress_entity_schema(spark_session, impress_api_url, impress_subtype)
+            # get_impress_entity_by_id_udf = udf(lambda x: print(x), ArrayType(impress_entity_schema))
+            # entity_df = entity_df.withColumn(impress_subtype, get_impress_entity_by_id_udf(entity_df[column_name]))
+    entity_df.show()
+    # entity_df.printSchema()
+    return entity_df
+
+
+def get_impress_entity_by_id(impress_api_url: str, impress_type: str, impress_id: str):
+    entity = requests.get("{}/{}/{}".format(impress_api_url, impress_type, impress_id)).json()
+    return entity
+
+
+def get_impress_entity_schema(spark_session: SparkSession, impress_api_url: str, impress_type: str):
+    first_entity = requests.get("{}/{}/{}".format(impress_api_url, impress_type, 1)).text
+    entity_rdd = spark_session.sparkContext.parallelize([first_entity])
+    return spark_session.read.json(entity_rdd).schema
+
+
+
+# print(json.dumps(get_impress_data('http://sandbox.mousephenotype.org/impress/', 'pipeline')))

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,2 +1,3 @@
 click
 owlready2
+requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def spark_session(request):
     :param request: pytest.FixtureRequest object
     :return spark: pyspark.sql.SparkSession
     """
-    conf = SparkConf().setAll([('spark.jars.packages', SparkConfig.SPARK_JAR_PACKAGES)])
+    conf = SparkConf().setAll([('spark.jars.packages', ','.join(SparkConfig.SPARK_JAR_PACKAGES))])
     spark = SparkSession.builder.appName("IMPC_ETL_TEST").config(conf=conf).getOrCreate()
     request.addfinalizer(lambda: spark.stop())
     quiet_py4j()

--- a/tests/jobs/test_impress_extractor.py
+++ b/tests/jobs/test_impress_extractor.py
@@ -1,0 +1,18 @@
+import pytest
+from impc_etl.jobs.extraction.impress_extractor import extract_impress
+from pyspark.sql import DataFrame, SparkSession
+
+pytestmark = pytest.mark.usefixtures("spark_session")
+
+
+#def test_extract_impress(spark_session: SparkSession):
+#    extract_impress(spark_session, 'http://sandbox.mousephenotype.org/impress/', 'pipeline')
+
+
+def test_jeremy_test(spark_session: SparkSession):
+    experiment_file = "/Users/federico/data/*experiment*"
+    experiments_df = spark_session.read.format("com.databricks.spark.xml") \
+        .options(rowTag="centre").load(experiment_file, )
+    experiments_df.show()
+    experiments_df.printSchema()
+    print(experiments_df.take(1)[0]['experiment'])


### PR DESCRIPTION
The previous idea for the extraction was to generate specialized dataframes for the different entities found in the different datasources, now we want to generate general dataframes for containing every entity on each datasource.

This PR also addresses the requirements for the use of this pipeline in a production setup of Apache Spark.