### PR TITLE
Modify script to transform impc images to web friendly format

### DIFF
--- a/impc_etl/cli/cli.py
+++ b/impc_etl/cli/cli.py
@@ -16,16 +16,16 @@ def cli():
 
 @click.command()
 @click.argument("input_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True))
-@click.argument("output_dir", type=click.Path(file_okay=False, dir_okay=True))
+@click.option("--output-dir", type=str)
 @click.option("--batch-size", default=1000, show_default=True, type=int, help="Batch size for processing")
-@click.option("--full-suffix", default="_full", type=str, help="Full size image suffix")
+@click.option("--full-suffix", default="", type=str, help="Full size image suffix")
 @click.option("--thumbnail-suffix", default="_thumbnail", type=str, help="Thumbnail suffix")
 @click.option("--thumbnail-width", default=200, show_default=True, type=int, help="Width of thumbnail")
 @click.option("--thumbnail-quality", default=80, show_default=True, type=int, help="Quality of thumbnail")
 @click.option("--start-processing",  is_flag=True, show_default=True, default=False, help="Whether to run the processing")
 def generate_jpegs(
     input_dir: str,
-    output_dir: str,
+    output_dir: str | None,
     batch_size: int,
     full_suffix: str,
     thumbnail_suffix: str,
@@ -38,11 +38,13 @@ def generate_jpegs(
     - Requires an input directory and an output directory.
     - Should allow to define suffixes for naming the full resolution and the thumbnail images to be generated.
     """
-    if os.path.exists(output_dir):
-        click.echo(f"Error: The output directory '{output_dir}' already exists.", err=True)
-        raise SystemExit(1)
-
-    os.mkdir(output_dir)
+    if output_dir is None:
+        output_dir = input_dir
+    else:
+        if os.path.exists(output_dir):
+            click.echo(f"Error: The output directory '{output_dir}' already exists.", err=True)
+            raise SystemExit(1)
+        os.mkdir(output_dir )
 
     input_dir = Path(input_dir)
     output_dir = Path(output_dir)

--- a/impc_etl/cli/cli.py
+++ b/impc_etl/cli/cli.py
@@ -30,7 +30,8 @@ def generate_jpegs(
     full_suffix: str,
     thumbnail_suffix: str,
     thumbnail_width: int,
-    thumbnail_quality: int
+    thumbnail_quality: int,
+    start_processing: bool
 ) -> None:
     """Generate JPEG images from an images directory which can have different sizes and file formats.
     For each image found on the input it should generate a JPEG image with a full resolution, and one image to be used as thumbnail.
@@ -56,25 +57,26 @@ def generate_jpegs(
                 f.write(f"{input_path.resolve()}\t{(output_path.parent/output_path.stem).resolve()}\n")
                 total_files += 1
 
-    click.echo(f"Generating JPEG files from {input_dir} to {output_dir}")
-    for batch_start in range(0, total_files, batch_size):
-        click.echo(f"Submit {batch_start} of {total_files}")
-        result = subprocess.run(
-            [
-                "python3",
-                "../jobs/transform/images_jpg_generation.py",
-                f"--manifest={manifest.resolve()}",
-                f"--batch-from={batch_start}",
-                f"--batch-to={batch_start + batch_size}",
-                f"--full-suffix={full_suffix}",
-                f"--thumbnail-suffix={thumbnail_suffix}",
-                f"--thumbnail-width={thumbnail_width}",
-                f"--thumbnail-quality={thumbnail_quality}"
-            ],
-            check=True,
-            # capture_output=True,
-            text=True
-        )
+    if start_processing:
+        click.echo(f"Generating JPEG files from {input_dir} to {output_dir}")
+        for batch_start in range(0, total_files, batch_size):
+            click.echo(f"Submit {batch_start} of {total_files}")
+            result = subprocess.run(
+                [
+                    "python3",
+                    "../jobs/transform/images_jpg_generation.py",
+                    f"--manifest={manifest.resolve()}",
+                    f"--batch-from={batch_start}",
+                    f"--batch-to={batch_start + batch_size}",
+                    f"--full-suffix={full_suffix}",
+                    f"--thumbnail-suffix={thumbnail_suffix}",
+                    f"--thumbnail-width={thumbnail_width}",
+                    f"--thumbnail-quality={thumbnail_quality}"
+                ],
+                check=True,
+                # capture_output=True,
+                text=True
+            )
 
 
 cli.add_command(generate_jpegs)

--- a/impc_etl/cli/cli.py
+++ b/impc_etl/cli/cli.py
@@ -17,11 +17,12 @@ def cli():
 @click.command()
 @click.argument("input_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True))
 @click.argument("output_dir", type=click.Path(file_okay=False, dir_okay=True))
-@click.option("--batch-size", default=1000, type=int, help="Batch size for processing (default: 1000)")
+@click.option("--batch-size", default=1000, show_default=True, type=int, help="Batch size for processing")
 @click.option("--full-suffix", default="_full", type=str, help="Full size image suffix")
 @click.option("--thumbnail-suffix", default="_thumbnail", type=str, help="Thumbnail suffix")
-@click.option("--thumbnail-width", default=200, type=int, help="Width of thumbnail (default: 200)")
-@click.option("--thumbnail-quality", default=80, type=int, help="Quality of thumbnail (default: 80)")
+@click.option("--thumbnail-width", default=200, show_default=True, type=int, help="Width of thumbnail")
+@click.option("--thumbnail-quality", default=80, show_default=True, type=int, help="Quality of thumbnail")
+@click.option("--start-processing",  is_flag=True, show_default=True, default=False, help="Whether to run the processing")
 def generate_jpegs(
     input_dir: str,
     output_dir: str,

--- a/impc_etl/cli/cli.py
+++ b/impc_etl/cli/cli.py
@@ -54,7 +54,7 @@ def generate_jpegs(
     click.echo(f"Generating list of input files for input directory {input_dir}")
     with open(manifest.resolve(), "w", encoding="utf-8") as f:
         for input_path in input_dir.rglob("*"):
-            if input_path.is_file():
+            if input_path.is_file() and (input_path != manifest):
                 output_path = output_dir / input_path.relative_to(input_dir)
                 f.write(f"{input_path.resolve()}\t{(output_path.parent/output_path.stem).resolve()}\n")
                 total_files += 1

--- a/impc_etl/jobs/transform/images_jpg_generation.py
+++ b/impc_etl/jobs/transform/images_jpg_generation.py
@@ -88,7 +88,6 @@ def process_images(
         else:
             convert_image(input_file, output_file, width=None, quality=100)
         convert_image(input_file, thumbnail_file, width=thumbnail_width, quality=thumbnail_quality)
-        print(input_file, output_file_basename)
 
 if __name__ == "__main__":
     process_images()

--- a/impc_etl/jobs/transform/images_jpg_generation.py
+++ b/impc_etl/jobs/transform/images_jpg_generation.py
@@ -83,8 +83,8 @@ def process_images(
         output_dir.mkdir(parents=True, exist_ok=True)
         output_file = output_file_basename + full_suffix + ".jpg"
         thumbnail_file = output_file_basename + thumbnail_suffix + ".jpg"
-        if Path(input_file).suffix.lower() in [".jpg", ".jpeg"]:
-            shutil.copy2(input_file, output_dir)
+        if Path(input_file).suffix.lower() in [".jpg", ".jpeg"] and (input_file != output_file):
+            shutil.copy2(input_file, output_file)
         else:
             convert_image(input_file, output_file, width=None, quality=100)
         convert_image(input_file, thumbnail_file, width=thumbnail_width, quality=thumbnail_quality)


### PR DESCRIPTION
- Script is able to use the input directory as the output directory.
  - Output directory is now an option.
  - If only the input directory is specified, the output files will be stored in the same directory.
- Script is able to run the manifest creation logic without starting the processing.
  - Created the `--start-processing` flag.
  - If there is no `--start-processing`, the script will generate manifest without converting files.
- Changed default of `--full-suffix` from `"_full"` to `""`.