### PR TITLE
Add auto-level and normalize flag for DICOM images

### DIFF
--- a/impc_etl/jobs/transform/images_jpg_generation.py
+++ b/impc_etl/jobs/transform/images_jpg_generation.py
@@ -27,8 +27,14 @@ def convert_image(input_path: str, output_path: str, width: int = None, quality:
     if not input_path or not output_path:
         raise ValueError("Both input_path and output_path must be specified.")
 
+    input_ext = Path(input_path).suffix.lower()
+
     # Construct the command.
     command = ["convert", input_path]
+
+    # Apply auto-level and normalize only for DICOM images.
+    if input_ext in [".dcm"]:
+        command.extend(["-auto-level", "-normalize"])
 
     # Add width resizing if specified.
     if width:
@@ -83,10 +89,12 @@ def process_images(
         output_dir.mkdir(parents=True, exist_ok=True)
         output_file = output_file_basename + full_suffix + ".jpg"
         thumbnail_file = output_file_basename + thumbnail_suffix + ".jpg"
+
         if Path(input_file).suffix.lower() in [".jpg", ".jpeg"] and (input_file != output_file):
             shutil.copy2(input_file, output_file)
         else:
             convert_image(input_file, output_file, width=None, quality=100)
+
         convert_image(input_file, thumbnail_file, width=thumbnail_width, quality=thumbnail_quality)
 
 if __name__ == "__main__":


### PR DESCRIPTION
DICOM images were too bright. Two flags `-auto-level` and`-normalize` were added to fix this issue.

Some comments about it: https://imagemagick.org/discourse-server/viewtopic.php?t=19748